### PR TITLE
Add requirements file and installation instructions

### DIFF
--- a/LAB1_loading_data.ipynb
+++ b/LAB1_loading_data.ipynb
@@ -52,6 +52,42 @@
   },
   {
    "cell_type": "code",
+   "execution_count": 138,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Requirement already satisfied: numpy in c:\\users\\kah32\\miniconda3\\envs\\streamlit-lab\\lib\\site-packages (from -r requirements.txt (line 1)) (1.23.5)\n",
+      "Requirement already satisfied: pandas in c:\\users\\kah32\\miniconda3\\envs\\streamlit-lab\\lib\\site-packages (from -r requirements.txt (line 2)) (1.5.2)\n",
+      "Requirement already satisfied: matplotlib in c:\\users\\kah32\\miniconda3\\envs\\streamlit-lab\\lib\\site-packages (from -r requirements.txt (line 3)) (3.6.3)\n",
+      "Requirement already satisfied: xlrd in c:\\users\\kah32\\miniconda3\\envs\\streamlit-lab\\lib\\site-packages (from -r requirements.txt (line 4)) (2.0.1)\n",
+      "Requirement already satisfied: geopandas in c:\\users\\kah32\\miniconda3\\envs\\streamlit-lab\\lib\\site-packages (from -r requirements.txt (line 5)) (1.0.1)\n",
+      "Requirement already satisfied: pytz>=2020.1 in c:\\users\\kah32\\miniconda3\\envs\\streamlit-lab\\lib\\site-packages (from pandas->-r requirements.txt (line 2)) (2022.7)\n",
+      "Requirement already satisfied: python-dateutil>=2.8.1 in c:\\users\\kah32\\miniconda3\\envs\\streamlit-lab\\lib\\site-packages (from pandas->-r requirements.txt (line 2)) (2.8.2)\n",
+      "Requirement already satisfied: fonttools>=4.22.0 in c:\\users\\kah32\\miniconda3\\envs\\streamlit-lab\\lib\\site-packages (from matplotlib->-r requirements.txt (line 3)) (4.38.0)\n",
+      "Requirement already satisfied: contourpy>=1.0.1 in c:\\users\\kah32\\miniconda3\\envs\\streamlit-lab\\lib\\site-packages (from matplotlib->-r requirements.txt (line 3)) (1.0.7)\n",
+      "Requirement already satisfied: pillow>=6.2.0 in c:\\users\\kah32\\miniconda3\\envs\\streamlit-lab\\lib\\site-packages (from matplotlib->-r requirements.txt (line 3)) (9.3.0)\n",
+      "Requirement already satisfied: cycler>=0.10 in c:\\users\\kah32\\miniconda3\\envs\\streamlit-lab\\lib\\site-packages (from matplotlib->-r requirements.txt (line 3)) (0.11.0)\n",
+      "Requirement already satisfied: pyparsing>=2.2.1 in c:\\users\\kah32\\miniconda3\\envs\\streamlit-lab\\lib\\site-packages (from matplotlib->-r requirements.txt (line 3)) (3.0.9)\n",
+      "Requirement already satisfied: packaging>=20.0 in c:\\users\\kah32\\miniconda3\\envs\\streamlit-lab\\lib\\site-packages (from matplotlib->-r requirements.txt (line 3)) (22.0)\n",
+      "Requirement already satisfied: kiwisolver>=1.0.1 in c:\\users\\kah32\\miniconda3\\envs\\streamlit-lab\\lib\\site-packages (from matplotlib->-r requirements.txt (line 3)) (1.4.4)\n",
+      "Requirement already satisfied: shapely>=2.0.0 in c:\\users\\kah32\\miniconda3\\envs\\streamlit-lab\\lib\\site-packages (from geopandas->-r requirements.txt (line 5)) (2.0.6)\n",
+      "Requirement already satisfied: pyproj>=3.3.0 in c:\\users\\kah32\\miniconda3\\envs\\streamlit-lab\\lib\\site-packages (from geopandas->-r requirements.txt (line 5)) (3.6.1)\n",
+      "Requirement already satisfied: pyogrio>=0.7.2 in c:\\users\\kah32\\miniconda3\\envs\\streamlit-lab\\lib\\site-packages (from geopandas->-r requirements.txt (line 5)) (0.9.0)\n",
+      "Requirement already satisfied: certifi in c:\\users\\kah32\\miniconda3\\envs\\streamlit-lab\\lib\\site-packages (from pyogrio>=0.7.2->geopandas->-r requirements.txt (line 5)) (2022.12.7)\n",
+      "Requirement already satisfied: six>=1.5 in c:\\users\\kah32\\miniconda3\\envs\\streamlit-lab\\lib\\site-packages (from python-dateutil>=2.8.1->pandas->-r requirements.txt (line 2)) (1.16.0)\n"
+     ]
+    }
+   ],
+   "source": [
+    "# install requirements if working from a blank environment (you may have to restart your kernel for the installations to take effect)\n",
+    "!pip install -r requirements.txt"
+   ]
+  },
+  {
+   "cell_type": "code",
    "execution_count": 1,
    "metadata": {},
    "outputs": [],

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+numpy
+pandas
+matplotlib
+xlrd
+geopandas


### PR DESCRIPTION
The notebook utilizes several external libraries without explicit instructions to install them. A requirements file might be helpful to include along with instructions on how to install them from a notebook